### PR TITLE
Drop Algolia search config on zui.brimdata.io for now

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -119,12 +119,6 @@ const config = {
         theme: lightCodeTheme,
         darkTheme: darkCodeTheme,
       },
-      algolia: {
-        appId: "WZNIEWJ5O6",
-        apiKey: "5b2387711eca356fb0d654336ae3f740",
-        indexName: "zed-brimdata",
-        externalUrlRegex: "zed\\.brimdata\\.io",
-      },
     }),
 };
 


### PR DESCRIPTION
I thought I saw a way to expand the Algolia crawler config to cover both zed.brimdata.io and zui.brimdata.io, which seemed like it would be a helpful convenience for users that didn't yet understand the breakdown of where Zed concepts end and app concepts begin. Unfortunately when I went to add the additional entry to the `startUrls`, it immediately kicked back an error saying this is "not allowed".

![image](https://user-images.githubusercontent.com/5934157/223499742-6fe847c2-30e2-47c2-a92b-510401fe2437.png)

I guess I am unsurprised given that we've been on a free plan. I did some web searches and saw at least one person saying that this could likely be rectified by reaching out to the DocSearch support people and asking for an adjustment in the config. I emailed documentationsearch@algolia.com last night explaining the situation and showing the screenshot. It kicked back an autoreply saying it may take a long time for them to respond. 🙁  If we got impatient I suppose we could look into starting a paid plan, but since we just migrated the site from the wiki where there wasn't a good search option, I figure we can be patient. In the meantime, here I'm proposing the removal of the Search tool for now, since at the moment it's only returning results from zed.brimdata.io, which is potentially helpful but also potentially confusing since they might search for app-specific concepts and think we lack content that's actually in the docs tree.