### PR TITLE
Exclude Twitter from link checker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -46,6 +46,7 @@ jobs:
             --header="Accept-Encoding:zstd,br,gzip,deflate"
             --exclude algolia.net
             --exclude github.com\/brimdata\/.*\/edit\/
+            --exclude twitter.com
             --exclude www.googletagmanager.com
             --exclude https://support.virustotal.com/hc/en-us/articles/115002146769-Comments
             --exclude https://github.com/brimdata/brimcap#


### PR DESCRIPTION
https://github.com/brimdata/website/pull/179 has the detailed explanation for why.