### PR TITLE
Fix GitHub link check exclusions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -49,9 +49,9 @@ jobs:
             --exclude twitter.com
             --exclude www.googletagmanager.com
             --exclude https://support.virustotal.com/hc/en-us/articles/115002146769-Comments
-            --exclude https://github.com/brimdata/brimcap#
+            --exclude https://github.com/brimdata/brimcap.*#
+            --exclude https://github.com/brimdata/zui.*#
             --exclude https://github.com/brimdata/build-suricata.*#
-            --exclude https://github.com/brimdata/brimcap/wiki.*#
       - name: Inform Slack users of failure
         uses: tiloio/slack-webhook-action@v1.1.2
         if: ${{ failure() }}


### PR DESCRIPTION
A recent [deploy](https://github.com/brimdata/zui-docs-site/actions/runs/8882824242) of the Zui docs site had some link checker failures and this PR fixes those. I tested out the updated config in a test staging deploy of the site and the link checker came back clean.