### PR TITLE
Exclude strftime site from link checker config

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,6 +52,7 @@ jobs:
             --exclude https://github.com/brimdata/brimcap.*#
             --exclude https://github.com/brimdata/zui.*#
             --exclude https://github.com/brimdata/build-suricata.*#
+            --exclude https://github.com/samsonjs/strftime.*#
       - name: Inform Slack users of failure
         uses: tiloio/slack-webhook-action@v1.1.2
         if: ${{ failure() }}


### PR DESCRIPTION
Ah good times! It seems every now and then I need to be reminded of how anchors in GitHub READMEs always look like failures to link checkers, such as was flagged in a [recent Actions run](https://github.com/brimdata/zui-docs-site/actions/runs/10515700636). Here I add another exclusion like the ones we've had in the past to shut it up. I have a personal link checker repo where I already confirmed this makes it run green again.