### PR TITLE
Drop reference to Zui as being v1.0.0

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -42,9 +42,6 @@ export default function Home() {
               >
                 Download
               </a>
-              <p className={clsx(styles.subText, styles.versionNumber)}>
-                v1.0.0
-              </p>
             </div>
           </div>
 


### PR DESCRIPTION
It's subtle, but I noticed there was a "v1.0.0" reference under the **Download** button on https://zui.brimdata.io/. We're way beyond that version and I doubt we want to be updating that with every release, so I'm just proposing dropping it.

I'm no HTML jockey but it seemed to render fine locally after this change. @jameskerr feel free to improve as you see fit. 😉 